### PR TITLE
Document stuff run before backdoor_setup()

### DIFF
--- a/xzre.c
+++ b/xzre.c
@@ -92,7 +92,7 @@ void xzre_secret_data_test(){}
 
 static void *get_elf_base(const char *path){
 	char cmdBuf[128];
-	char template[] = "grep -E 'r--p 00000000.*%s' /proc/%zu/maps | cut -d '-' -f1";
+	char template[] = "grep -E 'r--p 00000000.*%s' /proc/%d/maps | cut -d '-' -f1";
 	snprintf(cmdBuf, sizeof(cmdBuf), template, path, getpid());
 	FILE *hProc = popen(cmdBuf, "r");
 	memset(cmdBuf, 0x00, sizeof(cmdBuf));
@@ -200,7 +200,7 @@ void xzre_backdoor_setup(){
 		.shared = &shared,
 		.hook_params = &hook_params
 	};
-	printf("pid is %zu\n", getpid());
+	printf("pid is %d\n", getpid());
 	//asm volatile("jmp .");
 	if(!backdoor_setup(&para)){
 		puts("backdoor_setup() FAIL");
@@ -233,8 +233,8 @@ void main_shared(){
 		string_item_t *item = &strings.entries[i];
 		printf(
 			"----> %s\n"
-			"str %2d: id=0x%x, start=%p, end=%p, xref=%p (size: 0x%04lx, xref_offset: 0x%04lx\n"
-			"RVA_start: %p, RVA_end: %p, RVA_xref: %p\n\n",
+			"str %2d: id=0x%x, start=%p, end=%p, xref=%p (size: 0x%04zx, xref_offset: 0x%04zx\n"
+			"RVA_start: 0x%tx, RVA_end: 0x%tx, RVA_xref: 0x%tx\n\n",
 			StringXrefName[i],
 				i, item->string_id, item->func_start, item->func_end, item->xref,
 				(item->func_start && item->func_end) ? PTRDIFF(item->func_end, item->func_start) : 0,
@@ -258,8 +258,9 @@ int main(int argc, char *argv[]){
 		if(!res) break;
 		//hexdump(&ctx, sizeof(ctx));
 		printf(
-			"[%2d]: opcode: 0x%08x (orig:0x%08X)  (l: %2llu) -- "
-			"modrm: 0x%02x (%d, %d, %d), operand: %lx, mem_disp: %lx, rex.br: %d, f: %02hhx\n", i,
+			"[%2d]: opcode: 0x%08"PRIx32" (orig:0x%08"PRIX32")  (l: %2"PRIu64") -- "
+			"modrm: 0x%02"PRIx8" (%"PRId8", %"PRId8", %"PRId8"), operand: %"PRIx64", mem_disp: %"PRIx64", rex.br: %d, f: %02"PRIx8"\n",
+			i,
 			XZDASM_OPC(ctx.opcode), ctx.opcode,
 			ctx.instruction_size,
 			ctx.modrm, ctx.modrm_mod, ctx.modrm_reg, ctx.modrm_rm,
@@ -270,7 +271,7 @@ int main(int argc, char *argv[]){
 			ctx.flags);
 		printf("      --> ");
 		for(int i=0; i<ctx.instruction_size; i++){
-			printf("%02hhx ", ctx.instruction[i]);
+			printf("%02"PRIx8" ", ctx.instruction[i]);
 		}
 		printf("\n");
 	};

--- a/xzre.h
+++ b/xzre.h
@@ -51,6 +51,8 @@ typedef struct {
 #include <link.h>
 #endif
 
+typedef Elf64_Xword Elf64_Relr;
+
 #define UPTR(x) ((uptr)(x))
 #define PTRADD(a, b) (UPTR(a) + UPTR(b))
 #define PTRDIFF(a, b) (UPTR(a) - UPTR(b))

--- a/xzre.lds.in
+++ b/xzre.lds.in
@@ -20,6 +20,9 @@ SECTIONS_BEGIN()
 	DEFSYM(find_function_prologue, .text.lzma_raw_coder_memusaga)
 	DEFSYM(find_function, .text.lzma2_encoder_inia)
 	DEFSYM(get_lzma_allocator, .text.stream_decoder_memconfia)
+	DEFSYM(get_lzma_allocator_address, .text.stream_decoder_mt_ena)
+	DEFSYM(fake_lzma_alloc, .text.init_pric_tabla)
+	DEFSYM(fake_lzma_free, .text.stream_decoda)
 	DEFSYM(secret_data_append_from_call_site, .text.lzma_index_iter_rewina)
 	DEFSYM(elf_contains_vaddr, .text.parse_bcz)
 	DEFSYM(elf_parse, .text.get_literal_prica)
@@ -74,25 +77,15 @@ SECTIONS_BEGIN()
 SECTIONS_END(.bss)
 
 SECTIONS_BEGIN()
+	DEFSYM(fake_lzma_allocator_offset, .data.rel.ro.lookup_filter.part.0)
 	DEFSYM(fake_lzma_allocator, .data.rel.ro.decoders0)
+	DEFSYM(elf_functions_offset, .data.rel.ro.filter_optmap.0)
+	DEFSYM(elf_functions, .data.rel.ro.encoders0)
 SECTIONS_END(.data.rel.ro)
 
-/*
-TODO map this to cpuid_reloc_consts:
-0000000000000000 l     O .rodata.lzma12_mf_mao.0	0000000000000000 .hidden .Llzma_block_buffer_decode.0
-
-TODO map this to random_symbol;
-0000000000000000 l     O .rodata.lzma_lzma_encode	0000000000000008 .hidden .Lrc_read_destroy
-
-TODO map this to tls_get_addr_reloc_consts:
-0000000000000000 l     O .rodata.rc_encode	0000000000000000 .hidden .Llzma_block_uncomp_encode.0
-
-TODO map this to random_symbol_2;
-0000000000000000 l     O .rodata.lzma2_decode	0000000000000008 .hidden .Lx86_coder_destroy
-
-0000000000000000 l     O .data.rel.ro.lookup_filter.part.0	0000000000000008 .hidden .Llookup_filter.part.0
-0000000000000000 R_X86_64_64       .Ldecoder.1-0x0000000000000180
-
-0000000000000000 l     O .data.rel.ro.filter_optmap.0	0000000000000008 .hidden .Lfilter_optmap.0
-0000000000000000 R_X86_64_64       .Lencoder.1-0x00000000000002a0
-*/
+SECTIONS_BEGIN()
+	DEFSYM(cpuid_random_symbol, .rodata.lzma_lzma_encode)
+	DEFSYM(cpuid_reloc_consts, .rodata.lzma12_mf_mao.0)
+	DEFSYM(tls_get_addr_random_symbol, .rodata.lzma2_decode)
+	DEFSYM(tls_get_addr_reloc_consts, .rodata.rc_encode)
+SECTIONS_END(.rodata)

--- a/xzre.lds.in
+++ b/xzre.lds.in
@@ -24,6 +24,7 @@ SECTIONS_BEGIN()
 	DEFSYM(elf_contains_vaddr, .text.parse_bcz)
 	DEFSYM(elf_parse, .text.get_literal_prica)
 	DEFSYM(main_elf_parse, .text.lzma_filter_decoder_is_supportea)
+	DEFSYM(check_argument, .text.lzma_encoder_inia)
 	DEFSYM(elf_symbol_get, .text.crc_inia)
 	DEFSYM(elf_symbol_get_addr, .text.crc64_generia)
 	DEFSYM(elf_get_code_segment, .text.lzma_check_updata)
@@ -59,6 +60,7 @@ SECTIONS_BEGIN()
 	DEFSYM(call_backdoor_init_stage2, .text._get_cpuia)
 	DEFSYM(_cpuid, .text._cpuid)
 	DEFSYM(update_got_address, .text.lzma_stream_header_encoda)
+	DEFSYM(get_random_symbol_2_got_offset, .text.lzma_stream_flags_compara)
 	DEFSYM(backdoor_symbind64, .text.lz_encoder_prepara)
 	DEFSYM(hook_RSA_get0_key, .text.lzma_index_inia)
 	DEFSYM(hook_EVP_PKEY_set1_RSA, .text.lzma_index_memusaga)
@@ -76,9 +78,21 @@ SECTIONS_BEGIN()
 SECTIONS_END(.data.rel.ro)
 
 /*
-TODO map this to backdoor_cpuid_reloc_consts_t:
+TODO map this to cpuid_reloc_consts:
 0000000000000000 l     O .rodata.lzma12_mf_mao.0	0000000000000000 .hidden .Llzma_block_buffer_decode.0
 
 TODO map this to random_symbol;
 0000000000000000 l     O .rodata.lzma_lzma_encode	0000000000000008 .hidden .Lrc_read_destroy
+
+TODO map this to tls_get_addr_reloc_consts:
+0000000000000000 l     O .rodata.rc_encode	0000000000000000 .hidden .Llzma_block_uncomp_encode.0
+
+TODO map this to random_symbol_2;
+0000000000000000 l     O .rodata.lzma2_decode	0000000000000008 .hidden .Lx86_coder_destroy
+
+0000000000000000 l     O .data.rel.ro.lookup_filter.part.0	0000000000000008 .hidden .Llookup_filter.part.0
+0000000000000000 R_X86_64_64       .Ldecoder.1-0x0000000000000180
+
+0000000000000000 l     O .data.rel.ro.filter_optmap.0	0000000000000008 .hidden .Lfilter_optmap.0
+0000000000000000 R_X86_64_64       .Lencoder.1-0x00000000000002a0
 */

--- a/xzre.lds.in
+++ b/xzre.lds.in
@@ -42,6 +42,9 @@ SECTIONS_BEGIN()
 	DEFSYM(secret_data_append_singleton, .text.rc_read_inis)
 	DEFSYM(backdoor_init, .text._get_cpuia)
 	DEFSYM(backdoor_init_stage2, .text.lzma_validate_chaia)
+	DEFSYM(init_elf_entry_ctx, .text.read_output_and_waia)
+	DEFSYM(get_got_offset, .text.parse_delt1)
+	DEFSYM(get_cpuid_got_index, .text.lzma_stream_decoder_inia)
 	DEFSYM(backdoor_setup, .text.microlzma_encoder_inia)
 	DEFSYM(resolve_libc_imports, .text.lzma_index_buffer_encoda)
 	DEFSYM(process_shared_libraries, .text.lzma_index_stream_flaga)
@@ -53,6 +56,8 @@ SECTIONS_BEGIN()
 	DEFSYM(get_string_id, .text.simple_coder_updata)
 	DEFSYM(init_hook_functions, .text.lzma_delta_decoder_inis)
 	DEFSYM(_get_cpuid, .text._get_cpuid)
+	DEFSYM(call_backdoor_init_stage2, .text._get_cpuia)
+	DEFSYM(_cpuid, .text._cpuid)
 	DEFSYM(update_got_address, .text.lzma_stream_header_encoda)
 	DEFSYM(backdoor_symbind64, .text.lz_encoder_prepara)
 	DEFSYM(hook_RSA_get0_key, .text.lzma_index_inia)
@@ -69,3 +74,11 @@ SECTIONS_END(.bss)
 SECTIONS_BEGIN()
 	DEFSYM(fake_lzma_allocator, .data.rel.ro.decoders0)
 SECTIONS_END(.data.rel.ro)
+
+/*
+TODO map this to backdoor_cpuid_reloc_consts_t:
+0000000000000000 l     O .rodata.lzma12_mf_mao.0	0000000000000000 .hidden .Llzma_block_buffer_decode.0
+
+TODO map this to random_symbol;
+0000000000000000 l     O .rodata.lzma_lzma_encode	0000000000000008 .hidden .Lrc_read_destroy
+*/


### PR DESCRIPTION
Also a few other fixes to get the building passing without warning on Ubuntu 22.04